### PR TITLE
jabref: Use license file of package version

### DIFF
--- a/jabref/PKGBUILD
+++ b/jabref/PKGBUILD
@@ -18,7 +18,7 @@ optdepends=(
    'gsettings-desktop-schemas: For web search support'
 )
 source=(https://github.com/JabRef/jabref/releases/download/v${pkgver}/JabRef-${pkgver}.jar
-        https://raw.githubusercontent.com/JabRef/jabref/master/LICENSE.md
+        https://raw.githubusercontent.com/JabRef/jabref/v${pkgver}/LICENSE.md
         jabref.sh
         jabref.desktop)
 noextract=(JabRef-${pkgver}.jar)


### PR DESCRIPTION
The license file was recently changed, causing (1) the checksum test to fail and (2) the license file to become out of sync with what applies to the installed program version.
Download the matching the program version to avoid that.