### PR TITLE
Remove workaround for GCC 7 bug

### DIFF
--- a/openafs-modules-dkms/PKGBUILD
+++ b/openafs-modules-dkms/PKGBUILD
@@ -7,7 +7,7 @@
 pkgname=openafs-modules-dkms
 _srcname=openafs
 pkgver=1.6.21
-pkgrel=1
+pkgrel=2
 pkgdesc="Kernel module for OpenAFS (dkms)"
 arch=('i686' 'x86_64' 'armv7h')
 url="http://www.openafs.org"
@@ -19,7 +19,7 @@ options=(!emptydirs)
 source=(http://openafs.org/dl/${pkgver}/${_srcname}-${pkgver}-src.tar.bz2
         dkms.conf)
 sha256sums=('ba9c1f615edd53b64fc271ad369c49a816acedca70cdd090975033469a84118f'
-            'baa3ab82ab2bb801d3a57568b46d5844add91cf8fc100386459d91d004f80f4f')
+            'ea7d1e6dfb5006016e25738be722c8793765f52ad55c0bbf588dd7fdf2bdd2bf')
 
 prepare() {
   cd ${srcdir}/${_srcname}-${pkgver}

--- a/openafs-modules-dkms/dkms.conf
+++ b/openafs-modules-dkms/dkms.conf
@@ -14,6 +14,5 @@ MAKE[0]="(./configure --prefix=/usr \
               --disable-fuse-client \
               --with-linux-kernel-packaging \
               --with-linux-kernel-headers=${kernel_source_dir} \
-          && echo '#define STRUCT_GROUP_INFO_HAS_GID' >> src/config/afsconfig.h \
           && make ${MAKEFLAGS} )"
 CLEAN="[ ! -f Makefile ] || make clean"


### PR DESCRIPTION
GCC 7.1.1-3 in Arch Linux core no longer has the bug that the define worked around.