### PR TITLE
Pin Java to 8

### DIFF
--- a/jabref/PKGBUILD
+++ b/jabref/PKGBUILD
@@ -11,9 +11,9 @@ pkgver=3.8.2
 pkgrel=2
 pkgdesc="GUI frontend for BibTeX, written in Java"
 arch=('any')
-url="http://www.jabref.org/"
+url="https://www.jabref.org/"
 license=('MIT')
-depends=('java-runtime>=8')
+depends=('java-runtime=8')
 optdepends=(
    'gsettings-desktop-schemas: For web search support'
 )


### PR DESCRIPTION
JabRef currently does not support Java 9 (https://github.com/JabRef/jabref/issues/2594). Since Java 9 will be released soon, I think, it is better to pin Java 8.

I also updated to homepage to the SSL-enabled homepage.