### PR TITLE
Associate yed with application/x-graphml+xml files

### DIFF
--- a/yed/.SRCINFO
+++ b/yed/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = yed
 	pkgdesc = Very powerful graph editor written in java
 	pkgver = 3.20.1
-	pkgrel = 1
+	pkgrel = 2
 	epoch = 1
 	url = http://www.yworks.com/en/products_yed_about.html
 	install = yed.install
@@ -13,7 +13,7 @@ pkgbase = yed
 	source = yed
 	source = graphml+xml-mime.xml
 	sha256sums = f1b8c878e45d476fd99e950c3469e7d7d9b433dab4efad8c1f8938dec9e2d897
-	sha256sums = 245182a52896bdff3f2c995a066623619d600665630e789910c92d36725a0aca
+	sha256sums = cc6957cde6eba0d82ea523b0257f8c91fd1e330a1e2ad7d64890e48a2450aa98
 	sha256sums = 731b54c6e731704efe9847d78e2df474d59042452ace29d2786d76891295249e
 	sha256sums = e751b69ed8a25faf46d4e4016ed8f1774abc88679067934a6081348e3d6fc332
 

--- a/yed/PKGBUILD
+++ b/yed/PKGBUILD
@@ -11,7 +11,7 @@
 
 pkgname=yed
 pkgver=3.20.1
-pkgrel=1
+pkgrel=2
 epoch=1
 pkgdesc='Very powerful graph editor written in java'
 arch=('any')
@@ -23,7 +23,7 @@ source=("https://www.yworks.com/resources/yed/demo/yEd-${pkgver}.zip"
         'yed'
         'graphml+xml-mime.xml')
 sha256sums=('f1b8c878e45d476fd99e950c3469e7d7d9b433dab4efad8c1f8938dec9e2d897'
-            '245182a52896bdff3f2c995a066623619d600665630e789910c92d36725a0aca'
+            'cc6957cde6eba0d82ea523b0257f8c91fd1e330a1e2ad7d64890e48a2450aa98'
             '731b54c6e731704efe9847d78e2df474d59042452ace29d2786d76891295249e'
             'e751b69ed8a25faf46d4e4016ed8f1774abc88679067934a6081348e3d6fc332')
 

--- a/yed/yed.desktop
+++ b/yed/yed.desktop
@@ -5,4 +5,5 @@ Exec=yed %f
 StartupNotify=true
 StartupWMClass=com-yworks-A-yEd
 Name=yEd Graph Editor
+MimeType=application/x-graphml+xml;
 Categories=Application;Graphics;VectorGraphics;Java;


### PR DESCRIPTION
Associate `yed` with `application/x-graphml+xml` files, so that double clicking or `xdg-open` work.