### PR TITLE
openafs-modules: adapted kernel version heuristic to work with lts versions

### DIFF
--- a/openafs-modules/PKGBUILD
+++ b/openafs-modules/PKGBUILD
@@ -43,7 +43,12 @@ sha256sums=('53543a561fce67714fec9f2a6bf408c5cc1d061c7dc9d1459458275e8ccbfa79'
 
 # Heuristic to determine version of installed kernel
 # You can modify this if the heuristic fails
-_kernelver=$(ls -dt /usr/lib/modules/* | head -n1 | cut -d/ -f5)
+if uname -r | grep -q lts; then
+  # if you are currently running an lts kernel, only consider lts versions
+  _kernelver=$(ls -dt /usr/lib/modules/*lts* | head -n1 | cut -d/ -f5)
+else
+  _kernelver=$(ls -dt /usr/lib/modules/* | head -n1 | cut -d/ -f5)
+fi
 _extramodules="/usr/lib/modules/${_kernelver}/extramodules"
 
 prepare() {


### PR DESCRIPTION
The current heuristic may choose a non-lts kernel version found in `/usr/lib/modules/`, altough you are running an lts kernel. We talked about the problems of using `uname` directly in #15, so this is not an option.

In this version, `uname` is only used to determine if you are generally using an lts kernel or not. If that's the case, only lts versions in `/usr/lib/modules/` are considered. If you are not running an lts kernel, the behaviour is unchanged.

I hope that this is a satisfying solution. The only corner case I see is if someone is switching between lts and non-lts kernels -- but that's ok, I guess.