### PR TITLE
Update for meshtastic 2.3.3

### DIFF
--- a/meshtastic-python/.SRCINFO
+++ b/meshtastic-python/.SRCINFO
@@ -22,7 +22,9 @@ pkgbase = meshtastic-python
 	depends = python-tabulate
 	depends = python-timeago
 	optdepends = python-pytap2: TUN tunnel support
-	source = meshtastic-python-2.3.0.tar.gz::https://github.com/meshtastic/python/archive/refs/tags/2.3.0.tar.gz
-	sha256sums = 5f61d0dc70755463d528cc267fca597402263debc4164c572102cda18f670929
+	source = meshtastic-python-2.3.3.tar.gz::https://github.com/meshtastic/python/archive/refs/tags/2.3.3.tar.gz
+	source = https://github.com/meshtastic/python/commit/2746a8ebb623c9a934e79f366ae9203aa9e54a6a.patch
+	sha256sums = 3c5ba46e16170e7037ed39841321e333d5bbeeca36c7944db34b6fb0a9030f04
+	sha256sums = 2b1d145589d2a50914a6e5d3904a9f93fa1d8d48b72fb2a2f3ecb93a8ede0447
 
 pkgname = meshtastic-python

--- a/meshtastic-python/.SRCINFO
+++ b/meshtastic-python/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = meshtastic-python
 	pkgdesc = Python CLI and API for talking to Meshtastic devices
-	pkgver = 2.3.0
+	pkgver = 2.3.3
 	pkgrel = 1
 	url = https://github.com/meshtastic/python/
 	arch = any

--- a/meshtastic-python/PKGBUILD
+++ b/meshtastic-python/PKGBUILD
@@ -5,8 +5,8 @@
 
 pkgname=meshtastic-python
 _name=python
-_verbump=48fe844e1246e7b720dea36038c83f445aee2f61
-pkgver=2.3.0
+_verbump=2746a8ebb623c9a934e79f366ae9203aa9e54a6a
+pkgver=2.3.3
 pkgrel=1
 pkgdesc="Python CLI and API for talking to Meshtastic devices"
 arch=('any')
@@ -19,16 +19,17 @@ makedepends=(python-build python-installer python-wheel)
 depends=(python-bleak python-dotmap python-protobuf python-pexpect python-pypubsub python-pyqrcode python-pyserial python-pyyaml python-requests python-setuptools python-tabulate python-timeago)
 optdepends=('python-pytap2: TUN tunnel support')
 source=("${pkgname}-${pkgver}.tar.gz::https://github.com/meshtastic/python/archive/refs/tags/${pkgver}.tar.gz"
-#       "https://github.com/meshtastic/python/commit/${_verbump}.patch"
+        "https://github.com/meshtastic/python/commit/${_verbump}.patch"
 )
-sha256sums=('5f61d0dc70755463d528cc267fca597402263debc4164c572102cda18f670929')
+sha256sums=('3c5ba46e16170e7037ed39841321e333d5bbeeca36c7944db34b6fb0a9030f04'
+            '2b1d145589d2a50914a6e5d3904a9f93fa1d8d48b72fb2a2f3ecb93a8ede0447')
 
 prepare() {
     cd "$_name-$pkgver"
 
     # The tagged commits unfortuantely miss the version bump performed in the
     # release script, so we manually backport that change.
-#    patch -p1 < "${srcdir}"/${_verbump}.patch
+    patch -p1 < "${srcdir}"/${_verbump}.patch
 }
 
 build() {


### PR DESCRIPTION
Updated meshtastic-python to 2.3.3.

When I built it I had to bring back the manual patch in prepare.