### PR TITLE
Update kodi-addon-pvr-hts-git for Kodi v21 Omega

### DIFF
--- a/kodi-addon-pvr-hts-git/.SRCINFO
+++ b/kodi-addon-pvr-hts-git/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = kodi-addon-pvr-hts-git
 	pkgdesc = Tvheadend HTSP PVR client addon for Kodi
-	pkgver = r1063.c8e933b
+	pkgver = r1110.6c5564f
 	pkgrel = 1
 	url = https://github.com/kodi-pvr/pvr.hts
 	arch = armv7h
@@ -15,7 +15,7 @@ pkgbase = kodi-addon-pvr-hts-git
 	provides = kodi-addon-pvr-hts
 	conflicts = kodi-addon-pvr-hts
 	conflicts = kodi-pvr-addons
-	source = kodi-addon-pvr-hts-git::git+https://github.com/kodi-pvr/pvr.hts.git#branch=Nexus
+	source = kodi-addon-pvr-hts-git::git+https://github.com/kodi-pvr/pvr.hts.git#branch=Omega
 	md5sums = SKIP
 
 pkgname = kodi-addon-pvr-hts-git

--- a/kodi-addon-pvr-hts-git/PKGBUILD
+++ b/kodi-addon-pvr-hts-git/PKGBUILD
@@ -14,7 +14,7 @@
 #                                                                             #
 ###############################################################################
 
-API=20
+API=21
 
 pkgname=kodi-addon-pvr-hts-git
 pkgver=r1063.c8e933b
@@ -34,6 +34,7 @@ case "$API" in
   18)  source[0]="${pkgname}::git+https://github.com/kodi-pvr/pvr.hts.git#branch=Leia" ;;
   19)  source[0]="${pkgname}::git+https://github.com/kodi-pvr/pvr.hts.git#branch=Matrix" ;;
   20)  source[0]="${pkgname}::git+https://github.com/kodi-pvr/pvr.hts.git#branch=Nexus" ;;
+  21)  source[0]="${pkgname}::git+https://github.com/kodi-pvr/pvr.hts.git#branch=Omega" ;;
   99)  ;;
   *)   echo "Unknown API version. Follow instructions in PKGBUILD." && false
 esac

--- a/kodi-addon-pvr-hts-git/PKGBUILD
+++ b/kodi-addon-pvr-hts-git/PKGBUILD
@@ -17,7 +17,7 @@
 API=21
 
 pkgname=kodi-addon-pvr-hts-git
-pkgver=r1063.c8e933b
+pkgver=r1110.6c5564f
 pkgrel=1
 pkgdesc='Tvheadend HTSP PVR client addon for Kodi'
 arch=('armv7h' 'i686' 'x86_64')


### PR DESCRIPTION
Kodi 21 is in the Arch repos now and the corresponding kodi-pvr git branch exists, so it seems appropriate to update the PKGBUILD accordingly.