### PR TITLE
Re-add armv7h support

### DIFF
--- a/jdk11-temurin/.SRCINFO
+++ b/jdk11-temurin/.SRCINFO
@@ -5,6 +5,7 @@ pkgbase = jdk11-temurin
 	url = https://adoptium.net/
 	install = install_jdk11-temurin.sh
 	arch = x86_64
+	arch = armv7h
 	license = custom
 	depends = java-runtime-common>=3
 	depends = java-environment-common
@@ -48,5 +49,7 @@ pkgbase = jdk11-temurin
 	sha256sums = 0f53d0b34412d1a2f30c33bcd68a8f682f1fc86fc76bf290bbb91cb5c1ad28ed
 	source_x86_64 = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.23%2B9/OpenJDK11U-jdk_x64_linux_hotspot_11.0.23_9.tar.gz
 	sha256sums_x86_64 = 23e47ea7a3015be3240f21185fd902adebdcf76530757c9b482c7eb5bd3417c2
+	source_armv7h = https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.23%2B9/OpenJDK11U-jdk_arm_linux_hotspot_11.0.23_9.tar.gz
+    sha256sums_armv7h = 8077edc07a57d846c3d11286a7caf05ed6ca6d6c1234bf0e03611f18e187f075
 
 pkgname = jdk11-temurin

--- a/jdk11-temurin/PKGBUILD
+++ b/jdk11-temurin/PKGBUILD
@@ -18,7 +18,7 @@ _tag_ver_short=${_majorver}.${_minorver}.${_securityver}+${_updatever%.*}
 
 pkgname=jdk11-temurin
 pkgdesc="Temurin ${_majorver} (OpenJDK ${_majorver} Java binaries by Adoptium, formerly AdoptOpenJDK)"
-arch=('x86_64')
+arch=('x86_64' 'armv7h')
 url='https://adoptium.net/'
 license=('custom')
 
@@ -53,10 +53,12 @@ install=install_jdk11-temurin.sh
 options=(!strip)
 
 source_x86_64=(https://github.com/adoptium/temurin${_majorver}-binaries/releases/download/jdk-${_tag_ver/+/%2B}/OpenJDK${_majorver}U-jdk_x64_linux_hotspot_${_tag_ver_short/+/_}.tar.gz)
+source_armv7h=(https://github.com/adoptium/temurin${_majorver}-binaries/releases/download/jdk-${_tag_ver/+/%2B}/OpenJDK${_majorver}U-jdk_arm_linux_hotspot_${_tag_ver_short/+/_}.tar.gz)
 sha256sums=('502d5dbdde0e4ef009af0f088e8431e0c1721ba2967951e690bf86d184493f75'
             '464c9a7518831eef7cf952a7bd51a1f0d80c19910d21dc1fce693fa6c2ea65df'
             '0f53d0b34412d1a2f30c33bcd68a8f682f1fc86fc76bf290bbb91cb5c1ad28ed')
 sha256sums_x86_64=('23e47ea7a3015be3240f21185fd902adebdcf76530757c9b482c7eb5bd3417c2')
+sha256sums_armv7h=('8077edc07a57d846c3d11286a7caf05ed6ca6d6c1234bf0e03611f18e187f075')
 source=(freedesktop-java.desktop
         freedesktop-jconsole.desktop
         freedesktop-jshell.desktop)


### PR DESCRIPTION
ARM binaries have been regularly published along with the x86_64 ones again in time for a while now, I have been making changes locally after each new version but didn't remember to make a PR till now.